### PR TITLE
SSL support for Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ When cache seems outdated, we use the key `last-modified-cache:<client>` to orde
 
 ### Kafka interaction
 
-We use Kafka to collect and dispatch LOG from SDKs. You can set `KAFKA_URL` to interact with _(default is set to 127.0.0.1:9092)_. For now, `KAFKA_URL` is a string list of host:port separated by a comma. _(host1:9092,host2:9092,host3:9092)_. *TLS keys and certificates or SASL and are not supported.*
+We use Kafka to collect and dispatch LOG from SDKs. You can set `KAFKA_URL` to interact with _(default is set to kafka://127.0.0.1:9092)_. For now, `KAFKA_URL` is a string list of host:port separated by a comma. _(kafka://host1:9092,kafka://host2:9092,kafka://host3:9092)_.
+
+For SSL support, use **kafka+ssl://** and set `KAFKA_TRUSTED_CERT` _(default is /secrets/ca.crt)_, `KAFKA_CLIENT_CERT` _(default is /secrets/client-cert.pem)_ and `KAFKA_CLIENT_CERT_KEY` _(default is /secrets/client-key.pem)_ keys.
 
 LOG are published on `KAFKA_TOPIC` env var topic _(default is set to stat-logs)_. We use `deviceId` as key and the content of LOG as message.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "herow-sdk-backend",
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -4068,14 +4069,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tap/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tap/node_modules/ansi-styles": {
       "version": "3.2.1",
       "dev": true,
@@ -5257,17 +5250,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tap/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/tap/node_modules/supports-color": {
@@ -9147,10 +9129,6 @@
             "type-fest": "^0.21.3"
           }
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "extraneous": true
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "bundled": true,
@@ -9935,13 +9913,6 @@
                 "ansi-regex": "^5.0.0"
               }
             }
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "extraneous": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {


### PR DESCRIPTION
`KAFKA_URL` is migrated to work with SSL support.

Previously, `KAFKA_URL` syntax was `host1:9092,host2:9092`. Now syntax have to be `kafka://host1:9092,kafka://host2:9092` or `kafka+ssl://host1:9092,kafka+ssl://host2:9092`.

You have to provide 3 files to support SSL.
- KAFKA_TRUSTED_CERT
- KAFKA_CLIENT_CERT
- KAFKA_CLIENT_CERT_KEY