### PR TITLE
support of location permissions

### DIFF
--- a/app.test.js
+++ b/app.test.js
@@ -234,13 +234,24 @@ test('should fail to send informations when optins contains more than one elemen
     t.equal(response.statusCode, 400, 'with a status code 400')
 })
 
+test('should fail to send informations when location contains bad keys', async t => {
+    const response = await app.inject({
+        method: 'PUT',
+        url: '/v2/sdk/userinfo',
+        headers: {'authorization': 'OAuth test', 'x-version': '7.0.0', 'x-sdk': 'test', 'x-device-id': 'test', 'x-herow-id': 'test'},
+        payload: { optins: [ { type: 'USER_DATA', value: false } ], location: { status: 'BAD', precision: 'BAD' } }
+    })
+
+    t.equal(response.statusCode, 400, 'with a status code 400')
+})
+
 test('should send informations when adId is more than 10 characters and optins contains USER_DATA', async t => {
 
     const response = await app.inject({
         method: 'PUT',
         url: '/v2/sdk/userinfo',
         headers: {'authorization': 'OAuth test', 'x-version': '7.0.0', 'x-sdk': 'test', 'x-device-id': 'test', 'x-herow-id': 'test'},
-        payload: { adId: 'morethan10characters', optins: [ { type: 'USER_DATA', value: true } ], customId: "test" }
+        payload: { adId: 'morethan10characters', optins: [ { type: 'USER_DATA', value: true } ], customId: "test", location: { status: 'ALWAYS', precision: 'FINE' } }
     })
 
     t.equal(response.statusCode, 200, 'with a status code 200')

--- a/routes/information.js
+++ b/routes/information.js
@@ -22,6 +22,12 @@ module.exports = async function (fastify, options) {
                 value: { type: 'boolean' } 
               } 
             } 
+          },
+          location: { type: 'object',
+            properties: {
+              status: { type: 'string', enum: [ 'ALWAYS', 'WHILE_IN_USE', 'NOT_DETERMINED', 'DENIED' ] },
+              precision: { type: 'string', enum: [ 'FINE', 'COARSE' ] }
+            }
           }
         }
       },

--- a/routes/logs.js
+++ b/routes/logs.js
@@ -36,7 +36,11 @@ module.exports = async function (fastify, options) {
     req.body.data.db        = req.client
 
     const userinfo = await fastify.redis.get('device:' + req.deviceId)
-    req.body.data.custom_id = JSON.parse(userinfo)?.customId
+    const userinfo_json = JSON.parse(userinfo)
+
+    req.body.data.custom_id = userinfo_json?.customId
+    req.body.data.location_status = userinfo_json?.location?.status
+    req.body.data.location_precision = userinfo_json?.location?.precision
 
     await fastify.kafka.send({
       topic: process.env.KAFKA_TOPIC || 'stat-logs',


### PR DESCRIPTION
This is a proposal to integrate new user information.

By giving a new field `location` on `userinfo` payload, we can collect data about location permissions.

```
location: { type: 'object',
  properties: {
    status: { type: 'string', enum: [ 'ALWAYS', 'WHILE_IN_USE', 'NOT_DETERMINED', 'DENIED' ] },
    precision: { type: 'string', enum: [ 'FINE', 'COARSE' ] }
  }
}
```